### PR TITLE
强制以UTF-8编码读取config.json

### DIFF
--- a/QQ-forward.py
+++ b/QQ-forward.py
@@ -4,7 +4,7 @@ import json
 bot = CQHttp()
 
 #读取配置文件
-with open("config.json","r") as f:
+with open("config.json","r",encoding = 'UTF-8') as f:
     config = json.load(f)
 MiPush = config["MiPush"]
 FCM = config["FCM"]


### PR DESCRIPTION
修复“UnicodeDecodeError: ‘gbk‘ codec can‘t decode byte 0xaa in position xxx”错误